### PR TITLE
Added filename to Module#_compile() call.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,6 @@ module.exports = function(source) {
   if (this.cacheable) this.cacheable();
   var Module = module.constructor;
   var m = new Module();
-  m._compile(source);
+  m._compile(source, this.resourcePath);
   return 'module.exports = ' + JSON.stringify(m.exports);
 };


### PR DESCRIPTION
Fixes crash on Node 6.3.0 due to filename missing from Module#_compile() call.
